### PR TITLE
Align Qwen3 omni thinker with updated architecture

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -1382,6 +1382,7 @@ class MRotaryEmbedding(RotaryEmbedding):
                     st_idx = llm_pos_ids_list[-1].max().item() + 1 if len(llm_pos_ids_list) > 0 else 0
                     bos_len = 1
                     llm_pos_ids_list.append(torch.arange(bos_len).view(1, -1).expand(3, -1) + st_idx)
+                    st_idx = llm_pos_ids_list[-1].max().item() + 1 if len(llm_pos_ids_list) > 0 else 0
                     llm_pos_ids_list.append(torch.arange(bos_len).view(1, -1).expand(3, -1) + st_idx)
                     st_idx = llm_pos_ids_list[-1].max().item() + 1 if len(llm_pos_ids_list) > 0 else 0
                     audio_len = _get_feat_extract_output_lengths(audio_seqlens[audio_idx])
@@ -1418,6 +1419,7 @@ class MRotaryEmbedding(RotaryEmbedding):
                     st_idx = llm_pos_ids_list[-1].max().item() + 1 if len(llm_pos_ids_list) > 0 else 0
                     eos_len = 1
                     llm_pos_ids_list.append(torch.arange(eos_len).view(1, -1).expand(3, -1) + st_idx)
+                    st_idx = llm_pos_ids_list[-1].max().item() + 1 if len(llm_pos_ids_list) > 0 else 0
                     llm_pos_ids_list.append(torch.arange(eos_len).view(1, -1).expand(3, -1) + st_idx)
                     st += text_len + bos_len * 2 + audio_len + video_len + eos_len * 2
                     audio_idx += 1


### PR DESCRIPTION
## Summary
- extend the Qwen3 omni rotary position helper with context/sequence slicing support and safer defaults for empty inputs
- realign the Qwen3 omni thinker module with the latest VL MoE architecture, including deepstack buffer management and optional data-parallel vision setup

## Testing
- python -m compileall vllm/model_executor/models/qwen3_omni_moe_thinker.py vllm/model_executor/layers/rotary_embedding/mrope.py

------
https://chatgpt.com/codex/tasks/task_e_68dd0ced89888331b5410c5ebdd64c57