### PR TITLE
Limit encoder cache usage to tail segments

### DIFF
--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -66,15 +66,10 @@ class EncoderCacheManager:
     """
 
     def __init__(self,
-                 cache_size: int,
-                 *,
-                 tail_size: Optional[int] = None,
-                 max_items: Optional[int] = None):
-        self.cache_size = cache_size
-        self.encoder_cache_tail_size = (
-            cache_size if tail_size is None else max(tail_size, 0))
-        self.encoder_cache_max_item = (
-            cache_size if max_items is None else max(max_items, 0))
+                 tail_size: int,
+                 max_items: int):
+        self.encoder_cache_tail_size = tail_size
+        self.encoder_cache_max_item = max_items
         self.num_free_slots = self.encoder_cache_max_item
         self.num_freeable_slots = self.encoder_cache_max_item
 
@@ -94,15 +89,13 @@ class EncoderCacheManager:
 
         start, end = needed_range
         if start >= end:
-            return False
+            return True
 
         num_tokens = request.get_num_encoder_tokens(input_id)
         if num_tokens == 0:
             return True
 
         tail_len = min(num_tokens, self.encoder_cache_tail_size)
-        if tail_len == 0:
-            return False
         tail_start = max(num_tokens - tail_len, 0)
         return start >= tail_start
 

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -3,7 +3,7 @@
 
 from collections import OrderedDict
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from vllm.logger import init_logger
 from vllm.multimodal import MultiModalRegistry
@@ -40,14 +40,20 @@ class EncoderCacheManager:
     Oldest cached embeddings with no request referenced will be first evicted.
     
     Args:
-        cache_size: Limit the size of the cache, measured by the number of
-                    tokens from the input sequence.
+        cache_size: Historical limit of the cache, measured in tokens. The
+            value is still required for backward compatibility but is no longer
+            used for accounting when `tail_size` or `max_items` are provided.
 
     Attributes:
-        cache_size: Total cache capacity in encoder tokens.
-        num_free_slots: Current available cache capacity in encoder tokens.
+        cache_size: Total cache capacity measured in encoder tokens (legacy).
+        encoder_cache_tail_size: Number of tokens per encoder output retained
+            in the cache (tail length).
+        encoder_cache_max_item: Maximum number of encoder outputs that can be
+            stored simultaneously.
+        num_free_slots: Current available cache capacity measured in encoder
+            outputs.
         num_freeable_slots: Capacity that can be immediately reclaimed by
-            evicting entries with zero references (in encoder tokens).
+            evicting entries with zero references (in encoder outputs).
         cached: Mapping from mm_hash to a set of request IDs that currently
             reference the cached entry. If the set is empty, the entry exists
             but is not referenced by any request and is eligible for
@@ -59,29 +65,62 @@ class EncoderCacheManager:
             last call to get_freed_mm_hashes(). This list is cleared on return.
     """
 
-    def __init__(self, cache_size: int):
+    def __init__(self,
+                 cache_size: int,
+                 *,
+                 tail_size: Optional[int] = None,
+                 max_items: Optional[int] = None):
         self.cache_size = cache_size
-        self.num_free_slots = cache_size
-        self.num_freeable_slots = cache_size
+        self.encoder_cache_tail_size = (
+            cache_size if tail_size is None else max(tail_size, 0))
+        self.encoder_cache_max_item = (
+            cache_size if max_items is None else max(max_items, 0))
+        self.num_free_slots = self.encoder_cache_max_item
+        self.num_freeable_slots = self.encoder_cache_max_item
 
         # mm_hash of mm_data => ids of requests that reference the mm_data
         self.cached: dict[str, set[str]] = {}
 
-        # mm_hash of mm_data => num_encoder_tokens of the mm_data
+        # mm_hash of mm_data => cache slots required for the mm_data
         self.freeable: OrderedDict[str, int] = OrderedDict()
         self.freed: list[str] = []
 
-    def check_and_update_cache(self, request: Request, input_id: int) -> bool:
+    def _is_range_cached(self, request: Request, input_id: int,
+                         needed_range: Optional[Tuple[int, int]]) -> bool:
+        """Return True if the requested range is covered by the cached tail."""
+
+        if needed_range is None:
+            return True
+
+        start, end = needed_range
+        if start >= end:
+            return False
+
+        num_tokens = request.get_num_encoder_tokens(input_id)
+        if num_tokens == 0:
+            return True
+
+        tail_len = min(num_tokens, self.encoder_cache_tail_size)
+        if tail_len == 0:
+            return False
+        tail_start = max(num_tokens - tail_len, 0)
+        return start >= tail_start
+
+    def check_and_update_cache(self,
+                               request: Request,
+                               input_id: int,
+                               needed_range: Optional[Tuple[int, int]] = None
+                               ) -> bool:
         """Check if encoder output for a specific multimodal input is cached.
 
-        If the encoder output is cached, update `cached` to add the request id
-        to the set of request ids that reference the cached encoder output.
-        If the encoder output was previously not referenced by any request,
-        update `freeable` and `num_freeable_slots` accordingly.
-
         Args:
-            request: The request containing the multimodal input
-            input_id: Index of the multimodal input within the request
+            request: The request containing the multimodal input.
+            input_id: Index of the multimodal input within the request.
+            needed_range: Optional tuple representing the [start, end) range
+                (relative to the encoder output) needed by the scheduler in
+                this step. When provided, the method verifies the requested
+                range is within the cached tail. If the range extends beyond
+                the retained tail, the encoder output is treated as uncached.
 
         Returns:
             True if the encoder output for this input is already cached
@@ -91,17 +130,20 @@ class EncoderCacheManager:
         if mm_hash not in self.cached:
             return False
 
+        if not self._is_range_cached(request, input_id, needed_range):
+            return False
+
         # Cached but currently not referenced by any request
         if not self.cached[mm_hash]:
-            num_tokens = self.freeable.pop(mm_hash)
-            self.num_freeable_slots -= num_tokens
+            num_slots = self.freeable.pop(mm_hash, 0)
+            self.num_freeable_slots -= num_slots
 
         self.cached[mm_hash].add(request.request_id)
         return True
 
     def can_allocate(self, request: Request, input_id: int,
                      encoder_compute_budget: int,
-                     num_tokens_to_schedule: int) -> bool:
+                     num_items_to_schedule: int) -> bool:
         """Check if there's sufficient cache space for a multimodal input. 
         If there is, return True and update EncoderCacheManager state.
 
@@ -119,8 +161,8 @@ class EncoderCacheManager:
             input_id: Index of the multimodal input within the request.
             encoder_compute_budget: Number of encoder tokens allowed to be 
                 computed when this method is invoked.
-            num_tokens_to_schedule: Number of tokens already scheduled to be 
-                allocated with cache space when this method is invoked.
+            num_items_to_schedule: Number of encoder outputs already scheduled
+                to be allocated with cache space when this method is invoked.
 
         Returns:
             True if there's enough capacity to hold the encoder output for this
@@ -136,24 +178,24 @@ class EncoderCacheManager:
         if num_tokens > encoder_compute_budget:
             return False
 
-        num_tokens += num_tokens_to_schedule
+        num_slots_needed = 1 + num_items_to_schedule
 
         # Enough free slots
-        if num_tokens <= self.num_free_slots:
+        if num_slots_needed <= self.num_free_slots:
             return True
 
         # Not enough reclaimable slots
-        if num_tokens > self.num_freeable_slots:
+        if num_slots_needed > self.num_freeable_slots:
             return False
 
         # Not enough free slots but enough reclaimable slots
         # NOTE: Eviction takes place here, but physical memory is not freed
         # until model runner is notified by the scheduler output.
-        while num_tokens > self.num_free_slots:
-            mm_hash, num_free_token = self.freeable.popitem(last=False)
+        while num_slots_needed > self.num_free_slots:
+            mm_hash, num_slots = self.freeable.popitem(last=False)
             del self.cached[mm_hash]
             self.freed.append(mm_hash)
-            self.num_free_slots += num_free_token
+            self.num_free_slots += num_slots
         return True
 
     def allocate(self, request: Request, input_id: int) -> None:
@@ -172,16 +214,14 @@ class EncoderCacheManager:
         if mm_hash not in self.cached:
             self.cached[mm_hash] = set()
 
-        num_encoder_tokens = request.get_num_encoder_tokens(input_id)
-
         # NOTE: Encoder cache should always have enough space for encoder inputs
         # that are scheduled since eviction takes place at can_allocate().
-        assert self.num_free_slots >= num_encoder_tokens
-        assert self.num_freeable_slots >= num_encoder_tokens
+        assert self.num_free_slots >= 1
+        assert self.num_freeable_slots >= 1
 
         self.cached[mm_hash].add(request_id)
-        self.num_free_slots -= num_encoder_tokens
-        self.num_freeable_slots -= num_encoder_tokens
+        self.num_free_slots -= 1
+        self.num_freeable_slots -= 1
 
     def get_cached_input_ids(self, request: Request) -> set[int]:
         """Get all cached multimodal input IDs for a request.
@@ -214,9 +254,8 @@ class EncoderCacheManager:
             return
         self.cached[mm_hash].discard(req_id)
         if not self.cached[mm_hash]:
-            num_tokens = request.get_num_encoder_tokens(input_id)
-            self.freeable[mm_hash] = num_tokens
-            self.num_freeable_slots += num_tokens
+            self.freeable[mm_hash] = 1
+            self.num_freeable_slots += 1
 
     def free(self, request: Request) -> None:
         """Free all encoder input cache reference held by *request*.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -152,8 +152,14 @@ class Scheduler(SchedulerInterface):
         # NOTE: For the models without encoder (e.g., text-only models),
         # the encoder cache will not be initialized because cache size is 0
         # for these models.
+        encoder_cache_tail_size = getattr(
+            self.scheduler_config, "encoder_cache_tail_size", None)
+        encoder_cache_max_item = getattr(
+            self.scheduler_config, "encoder_cache_max_item", None)
         self.encoder_cache_manager = EncoderCacheManager(
-            cache_size=encoder_cache_size)
+            cache_size=encoder_cache_size,
+            tail_size=encoder_cache_tail_size,
+            max_items=encoder_cache_max_item)
 
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
@@ -743,7 +749,7 @@ class Scheduler(SchedulerInterface):
         # multiple encoder inputs per request), we need to create temporary
         # trackers for accounting at the encoder input level.
         mm_hashes_to_schedule = set()
-        num_tokens_to_schedule = 0
+        num_items_to_schedule = 0
         for i, mm_feature in enumerate(mm_features):
             start_pos = mm_feature.mm_position.offset
             num_encoder_tokens = mm_feature.mm_position.length
@@ -782,8 +788,14 @@ class Scheduler(SchedulerInterface):
                     # current step.
                     continue
 
+                needed_start = max(num_computed_tokens - start_pos, 0)
+                needed_end = min(
+                    num_computed_tokens + num_new_tokens - start_pos,
+                    num_encoder_tokens,
+                )
+
                 if self.encoder_cache_manager.check_and_update_cache(
-                        request, i):
+                        request, i, (needed_start, needed_end)):
                     # The encoder input is already computed and cached from a
                     # previous step.
                     continue
@@ -800,7 +812,7 @@ class Scheduler(SchedulerInterface):
 
             if not self.encoder_cache_manager.can_allocate(
                     request, i, encoder_compute_budget,
-                    num_tokens_to_schedule):
+                    num_items_to_schedule):
                 # The encoder cache is full or the encoder budget is exhausted.
                 # NOTE(woosuk): We assume that the encoder input tokens should
                 # be processed altogether, as the encoder usually uses
@@ -816,8 +828,7 @@ class Scheduler(SchedulerInterface):
                     # the request in this step.
                     num_new_tokens = 0
                 break
-
-            num_tokens_to_schedule += num_encoder_tokens
+            num_items_to_schedule += 1
             encoder_compute_budget -= num_encoder_tokens
             mm_hashes_to_schedule.add(request.mm_features[i].identifier)
             encoder_inputs_to_schedule.append(i)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -152,14 +152,10 @@ class Scheduler(SchedulerInterface):
         # NOTE: For the models without encoder (e.g., text-only models),
         # the encoder cache will not be initialized because cache size is 0
         # for these models.
-        encoder_cache_tail_size = getattr(
-            self.scheduler_config, "encoder_cache_tail_size", None)
-        encoder_cache_max_item = getattr(
-            self.scheduler_config, "encoder_cache_max_item", None)
+        encoder_cache_max_items = int(os.environ.get("VLLM_ENCODER_CACHE_MAX_ITEMS", "128"))
         self.encoder_cache_manager = EncoderCacheManager(
-            cache_size=encoder_cache_size,
-            tail_size=encoder_cache_tail_size,
-            max_items=encoder_cache_max_item)
+            tail_size=self.block_size,
+            max_items=encoder_cache_max_items)
 
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1651,7 +1651,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
                 stored_length = encoder_output.shape[0]
                 stored_start = max(num_encoder_tokens - stored_length, 0)
-                if start_idx < tail_start:
+                if start_idx < stored_start:
                     raise RuntimeError(
                         "Encoder cache does not contain the required "
                         "prefix for multimodal input "

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -251,8 +251,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         else:
             self.max_encoder_len = 0
 
-        self.encoder_cache_tail_size = getattr(
-            scheduler_config, "encoder_cache_tail_size", None)
+        self.encoder_cache_tail_size = self.cache_config.block_size
 
         # Sampler
         self.sampler = Sampler(logprobs_mode=self.model_config.logprobs_mode)
@@ -1601,24 +1600,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Cache the encoder outputs by mm_hash
         for (mm_hash, pos_info), output in zip(mm_hashes_pos, encoder_outputs):
-            total_tokens = output.shape[0]
-            tail_size = self.encoder_cache_tail_size
-            if tail_size is None or tail_size <= 0:
-                tail_start = 0
-            else:
-                tail_len = min(total_tokens, tail_size)
-                tail_start = max(total_tokens - tail_len, 0)
-
-            if tail_start > 0:
-                output = output[tail_start:]
-
-            is_embed = pos_info.is_embed
-            if is_embed is not None:
-                is_embed = is_embed[tail_start:tail_start + output.shape[0]]
-
             self.encoder_cache[mm_hash] = scatter_mm_placeholders(
                 output,
-                is_embed=is_embed,
+                is_embed=pos_info.is_embed,
             )
 
     def _gather_mm_embeddings(
@@ -1665,28 +1649,28 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 assert encoder_output is not None,\
                     f"Encoder cache miss for {mm_hash}."
 
-                tail_length = encoder_output.shape[0]
-                tail_start = max(num_encoder_tokens - tail_length, 0)
+                stored_length = encoder_output.shape[0]
+                stored_start = max(num_encoder_tokens - stored_length, 0)
                 if start_idx < tail_start:
                     raise RuntimeError(
                         "Encoder cache does not contain the required "
                         "prefix for multimodal input "
                         f"{mm_hash}: requested start {start_idx}, "
-                        f"available tail starts at {tail_start}.")
+                        f"available tail starts at {stored_start}.")
 
-                stored_start = start_idx - tail_start
-                stored_end = end_idx - tail_start
-                if stored_end > tail_length:
+                picked_start = start_idx - stored_start
+                picked_end = end_idx - stored_start
+                if picked_end > stored_length:
                     raise RuntimeError(
                         "Encoder cache slice exceeds cached tail for "
                         f"multimodal input {mm_hash}: requested end "
                         f"{end_idx}, available length {tail_length}.")
 
                 if (is_embed := pos_info.is_embed) is not None:
-                    is_embed = is_embed[start_idx:end_idx]
+                    is_embed = is_embed[picked_start:picked_end]
 
                 mm_embeds_item = gather_mm_placeholders(
-                    encoder_output[stored_start:stored_end],
+                    encoder_output[picked_start:picked_end],
                     is_embed=is_embed,
                 )
                 mm_embeds_req.append(mm_embeds_item)
@@ -1712,6 +1696,23 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 scheduler_output.total_num_scheduled_tokens)
 
         return mm_embeds
+
+    def _trim_mm_embeddings(self):
+        tail_size = self.encoder_cache_tail_size
+
+        for mm_hash, output in self.encoder_cache.items():
+            total_tokens = output.shape[0]
+
+            if total_tokens <= tail_size:
+                continue
+
+            tail_len = min(total_tokens, tail_size)
+            tail_start = max(total_tokens - tail_len, 0)
+
+            if tail_start > 0:
+                output_tail = output[tail_start:].copy()
+                self.encoder_cache[mm_hash] = output_tail
+                del output
 
     def _extract_encoder_inputs(
         self,
@@ -2006,6 +2007,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # Run the multimodal encoder if any.
             self._execute_mm_encoder(scheduler_output)
             mm_embeds = self._gather_mm_embeddings(scheduler_output)
+
+            # Trim to save only the tail
+            self._trim_mm_embeddings()
 
             # NOTE(woosuk): To unify token ids and soft tokens (vision
             # embeddings), we always use embeddings (rather than token ids)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -251,6 +251,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         else:
             self.max_encoder_len = 0
 
+        self.encoder_cache_tail_size = getattr(
+            scheduler_config, "encoder_cache_tail_size", None)
+
         # Sampler
         self.sampler = Sampler(logprobs_mode=self.model_config.logprobs_mode)
 
@@ -1598,9 +1601,24 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Cache the encoder outputs by mm_hash
         for (mm_hash, pos_info), output in zip(mm_hashes_pos, encoder_outputs):
+            total_tokens = output.shape[0]
+            tail_size = self.encoder_cache_tail_size
+            if tail_size is None or tail_size <= 0:
+                tail_start = 0
+            else:
+                tail_len = min(total_tokens, tail_size)
+                tail_start = max(total_tokens - tail_len, 0)
+
+            if tail_start > 0:
+                output = output[tail_start:]
+
+            is_embed = pos_info.is_embed
+            if is_embed is not None:
+                is_embed = is_embed[tail_start:tail_start + output.shape[0]]
+
             self.encoder_cache[mm_hash] = scatter_mm_placeholders(
                 output,
-                is_embed=pos_info.is_embed,
+                is_embed=is_embed,
             )
 
     def _gather_mm_embeddings(
@@ -1647,11 +1665,28 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 assert encoder_output is not None,\
                     f"Encoder cache miss for {mm_hash}."
 
+                tail_length = encoder_output.shape[0]
+                tail_start = max(num_encoder_tokens - tail_length, 0)
+                if start_idx < tail_start:
+                    raise RuntimeError(
+                        "Encoder cache does not contain the required "
+                        "prefix for multimodal input "
+                        f"{mm_hash}: requested start {start_idx}, "
+                        f"available tail starts at {tail_start}.")
+
+                stored_start = start_idx - tail_start
+                stored_end = end_idx - tail_start
+                if stored_end > tail_length:
+                    raise RuntimeError(
+                        "Encoder cache slice exceeds cached tail for "
+                        f"multimodal input {mm_hash}: requested end "
+                        f"{end_idx}, available length {tail_length}.")
+
                 if (is_embed := pos_info.is_embed) is not None:
                     is_embed = is_embed[start_idx:end_idx]
 
                 mm_embeds_item = gather_mm_placeholders(
-                    encoder_output[start_idx:end_idx],
+                    encoder_output[stored_start:stored_end],
                     is_embed=is_embed,
                 )
                 mm_embeds_req.append(mm_embeds_item)


### PR DESCRIPTION
## Summary
- keep only a configurable tail slice of each encoder output when caching and account for capacity per cached item
- update scheduler logic to respect the new tail-aware cache checks and allocation semantics
- trim encoder outputs before saving on the worker and validate requested slices against the retained tail during retrieval

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb696aaa7883319433af79a06c5944